### PR TITLE
Update gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,21 @@
-node_modules
+/node_modules/
 uploads
+
+# Exclusion fichiers et dossiers spécifiques OSX
+.DS_Store
+.AppleDouble
+.LSOverride
+Icon
+._*
+.DocumentRevisions-V100
+.fseventsd
+.Spotlight-V100
+.TemporaryItems
+.Trashes
+.VolumeIcon.icns
+.com.apple.timemachine.donotpresent
+.AppleDB
+.AppleDesktop
+Network Trash Folder
+Temporary Items
+.apdisk


### PR DESCRIPTION
- exclusion node_modules (la syntaxe n'était pas bonne dans le gitignore d'origine)
- exclusion répertoires et fichiers spécifiques OSX